### PR TITLE
Default contructor CheckedLink pojo

### DIFF
--- a/src/main/java/eu/clarin/cmdi/rasa/links/CheckedLink.java
+++ b/src/main/java/eu/clarin/cmdi/rasa/links/CheckedLink.java
@@ -15,12 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
 package eu.clarin.cmdi.rasa.links;
 
 import org.bson.Document;
 
 public class CheckedLink {
+
     private String url;
     private String method;
     private String message;
@@ -34,7 +34,11 @@ public class CheckedLink {
     private String record;
     private String expectedMimeType;
 
-    public CheckedLink(Document document){
+    public CheckedLink() {
+
+    }
+
+    public CheckedLink(Document document) {
         this.url = document.getString("url");
         this.method = document.getString("method");
         this.message = document.getString("message");
@@ -48,7 +52,6 @@ public class CheckedLink {
         this.redirectCount = document.getInteger("redirectCount");
         this.expectedMimeType = document.getString("expectedMimeType");
     }
-
 
     public String getUrl() {
         return url;


### PR DESCRIPTION
For tests (and possibly other implementations) it would be useful to be able to construct a `CheckedLink` object without providing a Mongo document. Since there are setters for all properties, I don't think this has the potential of compromising integrity.

Alternative approach would be to make CheckedLink immutable and passing in all values via the constructor.