### PR TITLE
Improvements to link resources implementation

### DIFF
--- a/src/main/java/eu/clarin/cmdi/rasa/linkResources/impl/ACDHCheckedLinkResource.java
+++ b/src/main/java/eu/clarin/cmdi/rasa/linkResources/impl/ACDHCheckedLinkResource.java
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
 package eu.clarin.cmdi.rasa.linkResources.impl;
 
 import com.mongodb.MongoException;
@@ -77,11 +76,13 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
             cursor = linksChecked.find().noCursorTimeout(true).iterator();
         }
 
-        while (cursor.hasNext()) {
-            result.add(new CheckedLink(cursor.next()));
+        try {
+            while (cursor.hasNext()) {
+                result.add(new CheckedLink(cursor.next()));
+            }
+        } finally {
+            cursor.close();
         }
-
-        cursor.close();
 
         return result.stream();
     }
@@ -99,11 +100,13 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
             cursor = linksChecked.find().skip(start).limit(end).noCursorTimeout(true).iterator();
         }
 
-        while (cursor.hasNext()) {
-            result.add(new CheckedLink(cursor.next()));
+        try {
+            while (cursor.hasNext()) {
+                result.add(new CheckedLink(cursor.next()));
+            }
+        } finally {
+            cursor.close();
         }
-
-        cursor.close();
 
         return result.stream();
     }
@@ -146,11 +149,13 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
             cursor = linksCheckedHistory.find(eq("url", url)).noCursorTimeout(true).sort(sort).iterator();
         }
 
-        while (cursor.hasNext()) {
-            checkedLinks.add(new CheckedLink(cursor.next()));
+        try {
+            while (cursor.hasNext()) {
+                checkedLinks.add(new CheckedLink(cursor.next()));
+            }
+        } finally {
+            cursor.close();
         }
-
-        cursor.close();
 
         return checkedLinks.stream();
     }
@@ -160,8 +165,12 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
         MongoCursor<String> cursor = linksChecked.distinct("collection", String.class).iterator();
 
         List<String> collections = new ArrayList<>();
-        while (cursor.hasNext()) {
-            collections.add(cursor.next());
+        try {
+            while (cursor.hasNext()) {
+                collections.add(cursor.next());
+            }
+        } finally {
+            cursor.close();
         }
         return collections;
     }
@@ -170,7 +179,6 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
     public Boolean save(CheckedLink checkedLink) {
 
         //separate mongo actions so that one of them doesn't disturb the other
-
         //save it to the history
         Bson filter = Filters.eq("url", checkedLink.getUrl());
         try {
@@ -209,7 +217,6 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
             //do nothing so that the whole thread doesnt die because of one url, just skip it
             return false;
         }
-
 
     }
 

--- a/src/main/java/eu/clarin/cmdi/rasa/linkResources/impl/ACDHCheckedLinkResource.java
+++ b/src/main/java/eu/clarin/cmdi/rasa/linkResources/impl/ACDHCheckedLinkResource.java
@@ -36,6 +36,8 @@ import java.util.*;
 import java.util.stream.Stream;
 
 import static com.mongodb.client.model.Filters.*;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public class ACDHCheckedLinkResource implements CheckedLinkResource {
 
@@ -65,50 +67,32 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
 
     @Override
     public Stream<CheckedLink> get(Optional<CheckedLinkFilter> filter) {
-        List<CheckedLink> result = new ArrayList<>();
-
-        MongoCursor<Document> cursor;
+        final Iterable<Document> documents;
 
         if (filter.isPresent()) {
             Bson mongoFilter = filter.get().getMongoFilter();
-            cursor = linksChecked.find(mongoFilter).noCursorTimeout(true).iterator();
+            documents = linksChecked.find(mongoFilter).noCursorTimeout(true);
         } else {
-            cursor = linksChecked.find().noCursorTimeout(true).iterator();
+            documents = linksChecked.find().noCursorTimeout(true);
         }
 
-        try {
-            while (cursor.hasNext()) {
-                result.add(new CheckedLink(cursor.next()));
-            }
-        } finally {
-            cursor.close();
-        }
-
-        return result.stream();
+        return StreamSupport.stream(documents.spliterator(), false)
+                .map((d) -> new CheckedLink(d));
     }
 
     @Override
     public Stream<CheckedLink> get(Optional<CheckedLinkFilter> filter, int start, int end) {
-        List<CheckedLink> result = new ArrayList<>();
-
-        MongoCursor<Document> cursor;
+        final Iterable<Document> documents;
 
         if (filter.isPresent()) {
             Bson mongoFilter = filter.get().getMongoFilter();
-            cursor = linksChecked.find(mongoFilter).skip(start).limit(end).noCursorTimeout(true).iterator();
+            documents = linksChecked.find(mongoFilter).skip(start).limit(end).noCursorTimeout(true);
         } else {
-            cursor = linksChecked.find().skip(start).limit(end).noCursorTimeout(true).iterator();
+            documents = linksChecked.find().skip(start).limit(end).noCursorTimeout(true);
         }
 
-        try {
-            while (cursor.hasNext()) {
-                result.add(new CheckedLink(cursor.next()));
-            }
-        } finally {
-            cursor.close();
-        }
-
-        return result.stream();
+        return StreamSupport.stream(documents.spliterator(), false)
+                .map((d) -> new CheckedLink(d));
     }
 
     @Override
@@ -162,17 +146,10 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
 
     @Override
     public List<String> getCollectionNames() {
-        MongoCursor<String> cursor = linksChecked.distinct("collection", String.class).iterator();
+        Iterable<String> collections = linksChecked.distinct("collection", String.class);
 
-        List<String> collections = new ArrayList<>();
-        try {
-            while (cursor.hasNext()) {
-                collections.add(cursor.next());
-            }
-        } finally {
-            cursor.close();
-        }
-        return collections;
+        return StreamSupport.stream(collections.spliterator(), false)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/eu/clarin/cmdi/rasa/linkResources/impl/ACDHLinkToBeCheckedResource.java
+++ b/src/main/java/eu/clarin/cmdi/rasa/linkResources/impl/ACDHLinkToBeCheckedResource.java
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
 package eu.clarin.cmdi.rasa.linkResources.impl;
 
 import com.mongodb.MongoException;
@@ -53,11 +52,13 @@ public class ACDHLinkToBeCheckedResource implements LinkToBeCheckedResource {
             cursor = linksToBeChecked.find().noCursorTimeout(true).iterator();
         }
 
-        while (cursor.hasNext()) {
-            result.add(new LinkToBeChecked(cursor.next()));
+        try {
+            while (cursor.hasNext()) {
+                result.add(new LinkToBeChecked(cursor.next()));
+            }
+        } finally {
+            cursor.close();
         }
-
-        cursor.close();
 
         return result.stream();
     }
@@ -75,17 +76,19 @@ public class ACDHLinkToBeCheckedResource implements LinkToBeCheckedResource {
             cursor = linksToBeChecked.find().noCursorTimeout(true).iterator();
         }
 
-        while (cursor.hasNext()) {
-            result.add(new LinkToBeChecked(cursor.next()));
+        try {
+            while (cursor.hasNext()) {
+                result.add(new LinkToBeChecked(cursor.next()));
+            }
+        } finally {
+            cursor.close();
         }
-
-        cursor.close();
 
         return result;
     }
 
     @Override
-    public Boolean save(LinkToBeChecked linkToBeChecked){
+    public Boolean save(LinkToBeChecked linkToBeChecked) {
         try {
             linksToBeChecked.insertOne(linkToBeChecked.getMongoDocument());
             return true;


### PR DESCRIPTION
While investigating some performance issues I identified a couple of potential improvements in the implementation of the ACDH.*Resource.java classes. Closing the cursor in a `finally` block should reduce the chances of connection leaks, and in some cases streams can be returned without first iterating over all documents and storing them in list. @coy123 up to you to decide if you want to incorporate these and if so to run some tests to ensure there are no regressions.