### PR TITLE
Mysql implementation code review/change suggestions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>${slf4j.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -93,6 +94,7 @@
             <groupId>org.apache.ibatis</groupId>
             <artifactId>ibatis-core</artifactId>
             <version>3.0</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/src/main/java/eu/clarin/cmdi/rasa/filters/CheckedLinkFilter.java
+++ b/src/main/java/eu/clarin/cmdi/rasa/filters/CheckedLinkFilter.java
@@ -25,6 +25,8 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 /**
  * This class creates a filter for the status table with the given values through the constructor
@@ -79,9 +81,10 @@ public interface CheckedLinkFilter extends Filter {
      * If a url matches the given variables in the filter but is not in inList, it won't be in the results
      * @param con database connection
      * @param inList filters out the results, only urls within this list can be in the results
+     * @param addInListParams function that adds parameters for the 'in list'; takes the next available parameter index and returns the parameter index to continue with
      * @return fully prepared statement with filter variables set and ready to execute
      * @throws SQLException can occur during preparing the statement
      */
-    PreparedStatement getStatement(Connection con, String inList) throws SQLException;
+    PreparedStatement getStatement(Connection con, String inList, BiFunction<PreparedStatement, Integer, Integer> addInListParams) throws SQLException;
 
 }

--- a/src/main/java/eu/clarin/cmdi/rasa/filters/CheckedLinkFilter.java
+++ b/src/main/java/eu/clarin/cmdi/rasa/filters/CheckedLinkFilter.java
@@ -61,16 +61,18 @@ public interface CheckedLinkFilter extends Filter {
     ZoneId getZone();
 
     /**
-     * Sets the start. If there are 20 results and start is set to 10, it will start from the 10th and go until 20.
+     * Sets the start.If there are 20 results and start is set to 10, it will start from the 10th and go until 20.
      * @param start starting line to read from the database
+     * @return this
      */
-    void setStart(int start);
+    CheckedLinkFilter setStart(int start);
 
     /**
-     * Sets the end. If there are 20 results and end is set to 10, it will start from the 0 and go until 10.
+     * Sets the end.If there are 20 results and end is set to 10, it will start from the 0 and go until 10.
      * @param end last line to read from the database
+     * @return this
      */
-    void setEnd(int end);
+    CheckedLinkFilter setEnd(int end);
 
     /**
      * Same as getStatement(Connection con) but only the urls within the inList will be returned if they match the filter variables.

--- a/src/main/java/eu/clarin/cmdi/rasa/filters/impl/ACDHCheckedLinkFilter.java
+++ b/src/main/java/eu/clarin/cmdi/rasa/filters/impl/ACDHCheckedLinkFilter.java
@@ -27,8 +27,6 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.StringJoiner;
 
 public class ACDHCheckedLinkFilter implements CheckedLinkFilter {
@@ -126,12 +124,14 @@ public class ACDHCheckedLinkFilter implements CheckedLinkFilter {
         return zone;
     }
 
-    public void setEnd(int limitEnd) {
+    public ACDHCheckedLinkFilter setEnd(int limitEnd) {
         this.end = limitEnd;
+        return this;
     }
 
-    public void setStart(int start) {
+    public ACDHCheckedLinkFilter setStart(int start) {
         this.start = start;
+        return this;
     }
 
     /**

--- a/src/main/java/eu/clarin/cmdi/rasa/filters/impl/ACDHCheckedLinkFilter.java
+++ b/src/main/java/eu/clarin/cmdi/rasa/filters/impl/ACDHCheckedLinkFilter.java
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
 package eu.clarin.cmdi.rasa.filters.impl;
 
 import eu.clarin.cmdi.rasa.filters.CheckedLinkFilter;
@@ -28,6 +27,7 @@ import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.StringJoiner;
+import java.util.function.BiFunction;
 
 public class ACDHCheckedLinkFilter implements CheckedLinkFilter {
 
@@ -136,7 +136,9 @@ public class ACDHCheckedLinkFilter implements CheckedLinkFilter {
 
     /**
      * Prepares the query based on the variables
-     * @param inList filters out the results, only urls within this list can be in the results
+     *
+     * @param inList filters out the results, only urls within this list can be
+     * in the results
      * @return prepared query to be used in preparing the statement
      */
     private String prepareQuery(String inList) {
@@ -148,13 +150,13 @@ public class ACDHCheckedLinkFilter implements CheckedLinkFilter {
 
         StringJoiner sj = new StringJoiner(" AND ");
 
-        if(status!=null){
+        if (status != null) {
             sj.add("statusCode>=? AND statusCode<=?");
         }
-        if(before!=null){
+        if (before != null) {
             sj.add("timestamp<?");
         }
-        if(after!=null){
+        if (after != null) {
             sj.add("timestamp>?");
         }
         if (collection != null && !collection.equals("Overall")) {
@@ -164,7 +166,7 @@ public class ACDHCheckedLinkFilter implements CheckedLinkFilter {
             sj.add(inList);
         }
 
-        if(sj.length()>0){
+        if (sj.length() > 0) {
             sb.append(" WHERE ").append(sj.toString());
         }
 
@@ -178,15 +180,18 @@ public class ACDHCheckedLinkFilter implements CheckedLinkFilter {
         return sb.toString();
     }
 
-
     /**
-     * This method prepares the statement with the filter's variables with the given query.
+     * This method prepares the statement with the filter's variables with the
+     * given query.
+     *
      * @param con database connection
      * @param query query to be prepared
-     * @return a fully prepared statement with the query and given parameters, the caller can directly execute and read the results
+     * @param addInListParams function that adds parameters for the 'in list'; takes the next available parameter index and returns the parameter index to continue with
+     * @return a fully prepared statement with the query and given parameters,
+     * the caller can directly execute and read the results
      * @throws SQLException can occur during preparing the statement
      */
-    private PreparedStatement prepareStatement(Connection con, String query) throws SQLException {
+    private PreparedStatement prepareStatement(Connection con, String query, BiFunction<PreparedStatement, Integer, Integer> addInListParams) throws SQLException {
         PreparedStatement statement = con.prepareStatement(query);
 
         //query setting done, now fill it
@@ -209,6 +214,10 @@ public class ACDHCheckedLinkFilter implements CheckedLinkFilter {
             i++;
         }
 
+        if (addInListParams != null) {
+            i = addInListParams.apply(statement, i);
+        }
+
         if (start > 0 && end > 0) {
 //            sb.append("LIMIT ? OFFSET ?");
             statement.setInt(i, end - start + 1);
@@ -224,18 +233,16 @@ public class ACDHCheckedLinkFilter implements CheckedLinkFilter {
         return statement;
     }
 
-
     @Override
     public PreparedStatement getStatement(Connection con) throws SQLException {
         String query = prepareQuery(null);
-        return prepareStatement(con, query);
+        return prepareStatement(con, query, null);
     }
 
     @Override
-    public PreparedStatement getStatement(Connection con, String inList) throws SQLException {
+    public PreparedStatement getStatement(Connection con, String inList, BiFunction<PreparedStatement, Integer, Integer> addInListParams) throws SQLException {
         String query = prepareQuery(inList);
-        return prepareStatement(con, query);
+        return prepareStatement(con, query, addInListParams);
     }
-
 
 }

--- a/src/main/java/eu/clarin/cmdi/rasa/linkResources/CheckedLinkResource.java
+++ b/src/main/java/eu/clarin/cmdi/rasa/linkResources/CheckedLinkResource.java
@@ -48,7 +48,7 @@ public interface CheckedLinkResource {
      * @return CheckedLink for the given url
      * @throws SQLException occurs if there was an error during statement preparation or execution
      */
-    CheckedLink get(String url) throws SQLException;
+    Optional<CheckedLink> get(String url) throws SQLException;
 
     /* retrieve for single url from collection */
 
@@ -60,7 +60,7 @@ public interface CheckedLinkResource {
      * @return Checked link for the given url from the given collection
      * @throws SQLException occurs if there was an error during statement preparation or execution
      */
-    CheckedLink get(String url, String collection) throws SQLException;
+    Optional<CheckedLink> get(String url, String collection) throws SQLException;
 
     /*
      * returned stream needs to be closed after use, so use it with try with resources

--- a/src/main/java/eu/clarin/cmdi/rasa/linkResources/impl/ACDHCheckedLinkResource.java
+++ b/src/main/java/eu/clarin/cmdi/rasa/linkResources/impl/ACDHCheckedLinkResource.java
@@ -34,65 +34,66 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class ACDHCheckedLinkResource implements CheckedLinkResource {
-
+    
     private enum Table {
         STATUS, HISTORY
     }
-
+    
     private final static Logger _logger = LoggerFactory.getLogger(ACDHCheckedLinkResource.class);
-
+    
     private Connection con;
-
+    
     public ACDHCheckedLinkResource(Connection con) {
         this.con = con;
     }
-
+    
     @Override
     public CheckedLink get(String url) throws SQLException {
-
+        
         String urlQuery = "SELECT * FROM status WHERE url=?";
-        PreparedStatement statement = con.prepareStatement(urlQuery);
-        statement.setString(1, url);
+        try (PreparedStatement statement = con.prepareStatement(urlQuery)) {
+            statement.setString(1, url);
+            
+            try (ResultSet rs = statement.executeQuery()) {
+                Record record = DSL.using(con).fetchOne(rs);
 
-        ResultSet rs = statement.executeQuery();
-
-        Record record = DSL.using(con).fetchOne(rs);
-        statement.close();
-
-        //only one element
-        return record == null ? null : new CheckedLink(record);
-
+                //only one element
+                return record == null ? null : new CheckedLink(record);
+            }
+        }
+        
     }
-
+    
     @Override
     public CheckedLink get(String url, String collection) throws SQLException {
-
+        
         String urlCollectionQuery = "SELECT * FROM status WHERE url=? AND collection=?";
-        PreparedStatement statement = con.prepareStatement(urlCollectionQuery);
-        statement.setString(1, url);
-        statement.setString(2, collection);
+        try (PreparedStatement statement = con.prepareStatement(urlCollectionQuery)) {
+            statement.setString(1, url);
+            statement.setString(2, collection);
+            
+            try (ResultSet rs = statement.executeQuery()) {
+                
+                Record record = DSL.using(con).fetchOne(rs);
 
-        ResultSet rs = statement.executeQuery();
-
-        Record record = DSL.using(con).fetchOne(rs);
-        statement.close();
-
-        //only one element
-        return record == null ? null : new CheckedLink(record);
-
+                //only one element
+                return record == null ? null : new CheckedLink(record);
+            }
+        }
     }
-
+    
     @Override
     public Stream<CheckedLink> get(Optional<CheckedLinkFilter> filter) throws SQLException {
         final String defaultQuery = "SELECT * FROM status";
         final PreparedStatement statement = getPreparedStatement(defaultQuery, filter, null);
         final ResultSet rs = statement.executeQuery();
-
+        
         return DSL.using(con)
                 .fetchStream(rs)
                 .map(CheckedLink::new)
@@ -107,8 +108,11 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
     }
 
     /**
-     * This method is used to be able to have the prepared statement creation in one line, so that it fits well in to a try-with-resources block
-     * Then the caller methods don't need to concern themselves with closing the statement.
+     * This method is used to be able to have the prepared statement creation in
+     * one line, so that it fits well in to a try-with-resources block Then the
+     * caller methods don't need to concern themselves with closing the
+     * statement.
+     *
      * @param defaultQuery
      * @param filter
      * @param inList
@@ -116,17 +120,15 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
      * @throws SQLException
      */
     private PreparedStatement getPreparedStatement(String defaultQuery, Optional<CheckedLinkFilter> filter, String inList) throws SQLException {
-        PreparedStatement statement;
         if (!filter.isPresent()) {
-            statement = con.prepareStatement(defaultQuery);
+            return con.prepareStatement(defaultQuery);
         } else {
             if (inList != null) {
-                statement = filter.get().getStatement(con, inList);
+                return filter.get().getStatement(con, inList);
             } else {
-                statement = filter.get().getStatement(con);
+                return filter.get().getStatement(con);
             }
         }
-        return statement;
     }
 
     //call this method in a try with resources so that the underlying resources are closed after use
@@ -135,11 +137,11 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
         if (start > end) {
             throw new IllegalArgumentException("start can't be greater than end.");
         }
-
+        
         if (start <= 0 && end <= 0) {
             throw new IllegalArgumentException("start and end can't less than or equal to 0 at the same time.");
         }
-
+        
         CheckedLinkFilter filter;
         if (filterOptional.isPresent()) {
             filter = filterOptional.get();
@@ -148,10 +150,10 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
         } else {
             filter = new ACDHCheckedLinkFilter(start, end);
         }
-
+        
         return get(Optional.of(filter));
     }
-
+    
     @Override
     public Map<String, CheckedLink> get(Collection<String> urls, Optional<CheckedLinkFilter> filter) throws SQLException {
 
@@ -159,32 +161,38 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
         //example query: select * from status where url in ('www.google.com','www.facebook.com');
         StringBuilder sb = new StringBuilder();
         sb.append(" url IN (");
-        String comma = "";
+        String comma = ""; //TODO: use stringjoiner
         for (String url : urls) {
             sb.append(comma);
             comma = ",";
-            sb.append("'").append(url).append("'");
+            sb.append("'?'");
         }
         sb.append(")");
-
-        String defaultQuery = "SELECT * FROM status WHERE" + sb.toString();
-
-        try (PreparedStatement statement = getPreparedStatement(defaultQuery, filter, sb.toString())) {
+        
+        final String queryInClause = sb.toString();
+        final String defaultQuery = "SELECT * FROM status WHERE" + queryInClause;
+        
+        try (PreparedStatement statement = getPreparedStatement(defaultQuery, filter, queryInClause)) {
+            //add URL parameters
+            final AtomicInteger urlIndex = new AtomicInteger(0);
+            for (String url : urls) {
+                statement.setString(urlIndex.getAndIncrement(), url);
+            }
             try (ResultSet rs = statement.executeQuery()) {
                 try (Stream<Record> recordStream = DSL.using(con).fetchStream(rs)) {
                     return recordStream.map(CheckedLink::new).collect(Collectors.toMap(CheckedLink::getUrl, Function.identity()));
                 }
             }
         }
-
+        
     }
-
+    
     @Override
     public Boolean save(CheckedLink checkedLink) throws SQLException {
 
         //get old checked link
         CheckedLink oldCheckedLink = get(checkedLink.getUrl());
-
+        
         if (oldCheckedLink != null) {
             //save to history
             saveToHistory(oldCheckedLink);
@@ -196,7 +204,7 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
         //save new one
         return insertCheckedLink(checkedLink, Table.STATUS);
     }
-
+    
     private PreparedStatement getInsertPreparedStatement(Table tableName) throws SQLException {
         final String insertStatusQuery = "INSERT INTO status(url,statusCode,method,contentType,byteSize,duration,timestamp,redirectCount,collection,record,expectedMimeType,message) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)";
         final String insertHistoryQuery = "INSERT INTO history(url,statusCode,method,contentType,byteSize,duration,timestamp,redirectCount,collection,record,expectedMimeType,message) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)";
@@ -209,10 +217,10 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
                 throw new RuntimeException("Unsupported table name" + tableName);
         }
     }
-
+    
     private Boolean insertCheckedLink(CheckedLink checkedLink, Table tableName) {
         try (PreparedStatement preparedStatement = getInsertPreparedStatement(tableName)) {
-
+            
             preparedStatement.setString(1, checkedLink.getUrl());
             preparedStatement.setInt(2, checkedLink.getStatus());
             preparedStatement.setString(3, checkedLink.getMethod());
@@ -228,34 +236,34 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
 
             //affected rows
             int row = preparedStatement.executeUpdate();
-
+            
             return row == 1;
-
+            
         } catch (SQLException e) {
             _logger.error("SQL Exception while saving " + checkedLink.getUrl() + " into " + tableName + ":" + e.getMessage());
             return false;
         }
     }
-
+    
     @Override
     public Boolean saveToHistory(CheckedLink checkedLink) throws SQLException {
         return insertCheckedLink(checkedLink, Table.HISTORY);
     }
-
+    
     @Override
     public Boolean delete(String url) throws SQLException {
         String deleteURLQuery = "DELETE FROM status WHERE url=?";
         try (PreparedStatement preparedStatement = con.prepareStatement(deleteURLQuery)) {
-
+            
             preparedStatement.setString(1, url);
 
             //affected rows
             int row = preparedStatement.executeUpdate();
-
+            
             return row == 1;
         }
     }
-
+    
     @Override
     public List<CheckedLink> getHistory(String url, Order order) throws SQLException {
 
@@ -263,14 +271,14 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
         String query = "SELECT * FROM history WHERE url=? ORDER BY timestamp " + order.name();
         try (PreparedStatement preparedStatement = con.prepareStatement(query)) {
             preparedStatement.setString(1, url);
-
+            
             try (ResultSet rs = preparedStatement.executeQuery()) {
-
+                
                 try (Stream<Record> recordStream = DSL.using(con).fetchStream(rs)) {
                     return recordStream.map(CheckedLink::new).collect(Collectors.toList());
                 }
             }
         }
-
+        
     }
 }

--- a/src/main/java/eu/clarin/cmdi/rasa/linkResources/impl/ACDHCheckedLinkResource.java
+++ b/src/main/java/eu/clarin/cmdi/rasa/linkResources/impl/ACDHCheckedLinkResource.java
@@ -56,7 +56,7 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
     @Override
     public CheckedLink get(String url) throws SQLException {
 
-        String urlQuery = "SELECT * FROM status WHERE url=?";
+        final String urlQuery = "SELECT * FROM status WHERE url=?";
         try (PreparedStatement statement = con.prepareStatement(urlQuery)) {
             statement.setString(1, url);
 
@@ -73,7 +73,7 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
     @Override
     public CheckedLink get(String url, String collection) throws SQLException {
 
-        String urlCollectionQuery = "SELECT * FROM status WHERE url=? AND collection=?";
+        final String urlCollectionQuery = "SELECT * FROM status WHERE url=? AND collection=?";
         try (PreparedStatement statement = con.prepareStatement(urlCollectionQuery)) {
             statement.setString(1, url);
             statement.setString(2, collection);
@@ -252,7 +252,7 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
 
     @Override
     public Boolean delete(String url) throws SQLException {
-        String deleteURLQuery = "DELETE FROM status WHERE url=?";
+        final String deleteURLQuery = "DELETE FROM status WHERE url=?";
         try (PreparedStatement preparedStatement = con.prepareStatement(deleteURLQuery)) {
 
             preparedStatement.setString(1, url);
@@ -266,9 +266,8 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
 
     @Override
     public List<CheckedLink> getHistory(String url, Order order) throws SQLException {
-
         //not requested much, so no need to optimize
-        String query = "SELECT * FROM history WHERE url=? ORDER BY timestamp " + order.name();
+        final String query = "SELECT * FROM history WHERE url=? ORDER BY timestamp " + order.name();
         try (PreparedStatement preparedStatement = con.prepareStatement(query)) {
             preparedStatement.setString(1, url);
 

--- a/src/main/java/eu/clarin/cmdi/rasa/linkResources/impl/ACDHCheckedLinkResource.java
+++ b/src/main/java/eu/clarin/cmdi/rasa/linkResources/impl/ACDHCheckedLinkResource.java
@@ -34,61 +34,62 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class ACDHCheckedLinkResource implements CheckedLinkResource {
-    
+
     private enum Table {
         STATUS, HISTORY
     }
-    
+
     private final static Logger _logger = LoggerFactory.getLogger(ACDHCheckedLinkResource.class);
-    
+
     private final Connection con;
-    
+
     public ACDHCheckedLinkResource(Connection con) {
         this.con = con;
     }
-    
+
     @Override
     public Optional<CheckedLink> get(String url) throws SQLException {
-        
+
         final String urlQuery = "SELECT * FROM status WHERE url=?";
         try (PreparedStatement statement = con.prepareStatement(urlQuery)) {
             statement.setString(1, url);
-            
+
             try (ResultSet rs = statement.executeQuery()) {
                 final Record record = DSL.using(con).fetchOne(rs);
                 return Optional.ofNullable(record).map(r -> new CheckedLink(r));
             }
         }
     }
-    
+
     @Override
     public Optional<CheckedLink> get(String url, String collection) throws SQLException {
-        
+
         final String urlCollectionQuery = "SELECT * FROM status WHERE url=? AND collection=?";
         try (PreparedStatement statement = con.prepareStatement(urlCollectionQuery)) {
             statement.setString(1, url);
             statement.setString(2, collection);
-            
+
             try (ResultSet rs = statement.executeQuery()) {
-                
+
                 final Record record = DSL.using(con).fetchOne(rs);
                 return Optional.ofNullable(record).map(r -> new CheckedLink(r));
             }
         }
     }
-    
+
     @Override
     public Stream<CheckedLink> get(Optional<CheckedLinkFilter> filter) throws SQLException {
         final String defaultQuery = "SELECT * FROM status";
         final PreparedStatement statement = getPreparedStatement(defaultQuery, filter, null, null);
         final ResultSet rs = statement.executeQuery();
-        
+
         return DSL.using(con)
                 .fetchStream(rs)
                 .map(CheckedLink::new)
@@ -133,40 +134,37 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
         if (start > end) {
             throw new IllegalArgumentException("start can't be greater than end.");
         }
-        
+
         if (start <= 0 && end <= 0) {
             throw new IllegalArgumentException("start and end can't less than or equal to 0 at the same time.");
         }
-        
+
         final Optional<CheckedLinkFilter> filter
                 = filterOptional
                         //filter was provided, combine with other params
                         .map(f -> f.setStart(start).setEnd(end)) //TG: do we really want to modify the passed filter??? we could also clone
                         //no filter was provided, create default filter 
                         .or(() -> Optional.of(new ACDHCheckedLinkFilter(start, end)));
-        
+
         return get(filter);
-        
+
     }
-    
+
     @Override
     public Map<String, CheckedLink> get(Collection<String> urls, Optional<CheckedLinkFilter> filter) throws SQLException {
 
         //if urlCollection is given, this is how all these from the collection are returned:
         //example query: select * from status where url in ('www.google.com','www.facebook.com');
-        StringBuilder sb = new StringBuilder();
-        sb.append(" url IN (");
-        String comma = ""; //TODO: use stringjoiner
-        for (String url : urls) {
-            sb.append(comma).append("?");
-            comma = ",";
-        }
-        sb.append(")");
         
-        final String queryInClause = sb.toString();
+        //construct a param list for URLs
+        final StringJoiner queryInClauseJoiner = new StringJoiner(",", " url IN (", ")");
+        //add a '?' for each URL
+        urls.forEach((url) -> queryInClauseJoiner.add("?"));
+        final String queryInClause = queryInClauseJoiner.toString();
+
         final String defaultQuery = "SELECT * FROM status WHERE" + queryInClause;
 
-        //callback to add URL parameters
+        //callback to add actual URLs as parameters to prepared statement
         final BiFunction<PreparedStatement, Integer, Integer> addUrlParms = (statement, i) -> {
             try {
                 for (String url : urls) {
@@ -177,24 +175,24 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
                 throw new RuntimeException("SQL exception while setting URL parameters for query", ex);
             }
         };
-        
+
         try (PreparedStatement statement = getPreparedStatement(defaultQuery, filter.or(() -> Optional.of(new ACDHCheckedLinkFilter(null))), queryInClause, addUrlParms)) {
-            
+
             try (ResultSet rs = statement.executeQuery()) {
                 try (Stream<Record> recordStream = DSL.using(con).fetchStream(rs)) {
                     return recordStream.map(CheckedLink::new).collect(Collectors.toMap(CheckedLink::getUrl, Function.identity()));
                 }
             }
         }
-        
+
     }
-    
+
     @Override
     public Boolean save(CheckedLink checkedLink) throws SQLException {
 
         //get old checked link
         final Optional<CheckedLink> oldCheckedLink = get(checkedLink.getUrl());
-        
+
         if (oldCheckedLink.isPresent()) {
             //save to history
             saveToHistory(oldCheckedLink.get());
@@ -206,7 +204,7 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
         //save new one
         return insertCheckedLink(checkedLink, Table.STATUS);
     }
-    
+
     private PreparedStatement getInsertPreparedStatement(Table tableName) throws SQLException {
         final String insertStatusQuery = "INSERT INTO status(url,statusCode,method,contentType,byteSize,duration,timestamp,redirectCount,collection,record,expectedMimeType,message) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)";
         final String insertHistoryQuery = "INSERT INTO history(url,statusCode,method,contentType,byteSize,duration,timestamp,redirectCount,collection,record,expectedMimeType,message) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)";
@@ -219,10 +217,10 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
                 throw new RuntimeException("Unsupported table name" + tableName);
         }
     }
-    
+
     private Boolean insertCheckedLink(CheckedLink checkedLink, Table tableName) {
         try (PreparedStatement preparedStatement = getInsertPreparedStatement(tableName)) {
-            
+
             preparedStatement.setString(1, checkedLink.getUrl());
             preparedStatement.setInt(2, checkedLink.getStatus());
             preparedStatement.setString(3, checkedLink.getMethod());
@@ -238,48 +236,48 @@ public class ACDHCheckedLinkResource implements CheckedLinkResource {
 
             //affected rows
             int row = preparedStatement.executeUpdate();
-            
+
             return row == 1;
-            
+
         } catch (SQLException e) {
             _logger.error("SQL Exception while saving " + checkedLink.getUrl() + " into " + tableName + ":" + e.getMessage());
             return false;
         }
     }
-    
+
     @Override
     public Boolean saveToHistory(CheckedLink checkedLink) throws SQLException {
         return insertCheckedLink(checkedLink, Table.HISTORY);
     }
-    
+
     @Override
     public Boolean delete(String url) throws SQLException {
         final String deleteURLQuery = "DELETE FROM status WHERE url=?";
         try (PreparedStatement preparedStatement = con.prepareStatement(deleteURLQuery)) {
-            
+
             preparedStatement.setString(1, url);
 
             //affected rows
             int row = preparedStatement.executeUpdate();
-            
+
             return row == 1;
         }
     }
-    
+
     @Override
     public List<CheckedLink> getHistory(String url, Order order) throws SQLException {
         //not requested much, so no need to optimize
         final String query = "SELECT * FROM history WHERE url=? ORDER BY timestamp " + order.name();
         try (PreparedStatement preparedStatement = con.prepareStatement(query)) {
             preparedStatement.setString(1, url);
-            
+
             try (ResultSet rs = preparedStatement.executeQuery()) {
-                
+
                 try (Stream<Record> recordStream = DSL.using(con).fetchStream(rs)) {
                     return recordStream.map(CheckedLink::new).collect(Collectors.toList());
                 }
             }
         }
-        
+
     }
 }

--- a/src/test/java/eu/clarin/cmdi/rasa/ACDHCheckedLinkResourceTest.java
+++ b/src/test/java/eu/clarin/cmdi/rasa/ACDHCheckedLinkResourceTest.java
@@ -55,12 +55,14 @@ public class ACDHCheckedLinkResourceTest extends TestConfig {
     public void basicGETTestShouldReturnCorrectResults() throws SQLException {
 
         CheckedLink expected = new CheckedLink("http://www.ailla.org/waiting.html", "HEAD", 200, "text/html; charset=UTF-8", 100, 132, then, "Ok", "NotGoogle", 0, "record", null);
-        CheckedLink actual = checkedLinkResource.get("http://www.ailla.org/waiting.html");
-        assertEquals(expected, actual);
+        Optional<CheckedLink> actual = checkedLinkResource.get("http://www.ailla.org/waiting.html");
+        assertTrue(actual.isPresent());
+        assertEquals(expected, actual.get());
 
         for (String url : urls) {
-            CheckedLink checkedLink = checkedLinkResource.get(url);
-            assertEquals(checkedLink.getUrl(), url);
+            Optional<CheckedLink>  checkedLink = checkedLinkResource.get(url);
+            assertTrue(actual.isPresent());
+            assertEquals(checkedLink.get().getUrl(), url);
         }
     }
 
@@ -68,9 +70,10 @@ public class ACDHCheckedLinkResourceTest extends TestConfig {
     public void basicGETWithCollectionTestShouldReturnCorrectResults() throws SQLException {
 
         for (String url : googleUrls) {
-            CheckedLink checkedLink = checkedLinkResource.get(url, "Google");
-            assertEquals(checkedLink.getUrl(), url);
-            assertEquals(checkedLink.getCollection(), "Google");
+            Optional<CheckedLink> checkedLink = checkedLinkResource.get(url, "Google");
+            assertTrue(checkedLink.isPresent());
+            assertEquals(checkedLink.get().getUrl(), url);
+            assertEquals(checkedLink.get().getCollection(), "Google");
         }
     }
 
@@ -233,7 +236,7 @@ public class ACDHCheckedLinkResourceTest extends TestConfig {
 
 
         checkedLinkResource.save(checkedLink1);
-        assertEquals(checkedLink1, checkedLinkResource.get(testURL));
+        assertEquals(checkedLink1, checkedLinkResource.get(testURL).get());
 
         List<CheckedLink> history = checkedLinkResource.getHistory(testURL, CheckedLinkResource.Order.DESC);
         assertEquals(1, history.size());
@@ -241,7 +244,7 @@ public class ACDHCheckedLinkResourceTest extends TestConfig {
 
         //add again, history should have 2
         checkedLinkResource.save(checkedLink2);
-        assertEquals(checkedLink2, checkedLinkResource.get(testURL));
+        assertEquals(checkedLink2, checkedLinkResource.get(testURL).get());
 
         history = checkedLinkResource.getHistory(testURL, CheckedLinkResource.Order.DESC);
         assertEquals(2, history.size());

--- a/src/test/java/eu/clarin/cmdi/rasa/ACDHCheckedLinkResourceTest.java
+++ b/src/test/java/eu/clarin/cmdi/rasa/ACDHCheckedLinkResourceTest.java
@@ -175,6 +175,9 @@ public class ACDHCheckedLinkResourceTest extends TestConfig {
         assertEquals(googleURLs.get(1), links.get(googleURLs.get(1)).getUrl());
         //shouldnt be in there
         assertNull(links.get("https://drive.google.com"));
+        
+        links = checkedLinkResource.get(Collections.emptyList(), Optional.empty());
+        assertEquals(0, links.size());
     }
 
     @Test


### PR DESCRIPTION
For now I have focussed on the `ACDHCheckedLinkResource` class and its direct 'neighbours'

- suggestions for code cleanliness, readability (tried to hold back from making too many suggestions that are just matter of taste or preference 😇)
- changed return type of two `CheckedLinkResource` methods to  `Optional<CheckedLink>` because returning null is no longer a necessary evil
- rewrote method that retrieves by URL collection to (`Map<String, CheckedLink> get(Collection<String> urls, ....`) pass the URLs as parameters to the prepared statement rather than constructing the clause through string concatenation (should be safer in various ways)
